### PR TITLE
Refactor/api call and eslint#103

### DIFF
--- a/pong-game/.eslintrc.json
+++ b/pong-game/.eslintrc.json
@@ -1,30 +1,30 @@
-{
-  "root": true,
-  "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint", "prettier"],
-  "parserOptions": {
-    "project": "./tsconfig.json",
-    "createDefaultProgram": true
-  },
-  "env": {
-    // 전역객체를 eslint가 인식하는 구간
-    "browser": true, // document나 window 인식되게 함
-    "node": true,
-    "es6": true
-  },
-  "ignorePatterns": ["node_modules/"], // eslint 미적용될 폴더나 파일 명시
-  "extends": [
-    // "airbnb",
-    // "airbnb-typescript",
-    // "airbnb/hooks",
-    "next/core-web-vitals",
-    "plugin:@typescript-eslint/recommended", // ts 권장
-    "plugin:prettier/recommended", // eslint의 포매팅을 prettier로 사용.
-    "prettier" // eslint-config-prettier prettier와 중복된 eslint 규칙 제거
-  ],
-  "rules": {
-    // 경고표시, 파일 확장자를 .ts나 .tsx 모두 허용함
-    "react/jsx-filename-extension": ["warn", { "extensions": [".ts", ".tsx"] }],
-    "no-useless-catch": "off" // 불필요한 catch 못쓰게 하는 기능 끔
-  }
-}
+// {
+//   "root": true,
+//   "parser": "@typescript-eslint/parser",
+//   "plugins": ["@typescript-eslint", "prettier"],
+//   "parserOptions": {
+//     "project": "./tsconfig.json",
+//     "createDefaultProgram": true
+//   },
+//   "env": {
+//     // 전역객체를 eslint가 인식하는 구간
+//     "browser": true, // document나 window 인식되게 함
+//     "node": true,
+//     "es6": true
+//   },
+//   "ignorePatterns": ["node_modules/"], // eslint 미적용될 폴더나 파일 명시
+//   "extends": [
+//     // "airbnb",
+//     // "airbnb-typescript",
+//     // "airbnb/hooks",
+//     "next/core-web-vitals",
+//     "plugin:@typescript-eslint/recommended", // ts 권장
+//     "plugin:prettier/recommended", // eslint의 포매팅을 prettier로 사용.
+//     "prettier" // eslint-config-prettier prettier와 중복된 eslint 규칙 제거
+//   ],
+//   "rules": {
+//     // 경고표시, 파일 확장자를 .ts나 .tsx 모두 허용함
+//     "react/jsx-filename-extension": ["warn", { "extensions": [".ts", ".tsx"] }],
+//     "no-useless-catch": "off" // 불필요한 catch 못쓰게 하는 기능 끔
+//   }
+// }

--- a/pong-game/components/Chat/ChatInfoLog/ChatLog.tsx
+++ b/pong-game/components/Chat/ChatInfoLog/ChatLog.tsx
@@ -12,11 +12,11 @@ function ChatLog(): JSX.Element {
   const { myNickname } = useNickNameImage()
   const messageEndRef = useRef<HTMLDivElement | null>(null)
 
-  const channelMessage = channelLog.map((message) => {
+  const channelMessage = channelLog.map((message, index) => {
     if (message.eventType) {
       return (
         <ChannelNotice
-          key={message.channelId}
+          key={index}
           nickname={message.nickname}
           eventType={message.eventType}
           channelId={message.channelId}
@@ -27,7 +27,7 @@ function ChatLog(): JSX.Element {
     if (myNickname !== message.nickname) {
       return (
         <OpponentMessage
-          key={message.channelId}
+          key={index}
           nickname={message.nickname}
           message={message.message}
           time={message.time}
@@ -36,7 +36,7 @@ function ChatLog(): JSX.Element {
     } else {
       return (
         <MyMessage
-          key={message.channelId}
+          key={index}
           nickname={message.nickname}
           message={message.message}
           time={message.time}

--- a/pong-game/components/Chat/ChatInfoLog/ChatPassword.tsx
+++ b/pong-game/components/Chat/ChatInfoLog/ChatPassword.tsx
@@ -6,6 +6,7 @@ import styles from './ChatPassword.module.scss'
 import ChatPasswordInput from '../Input/ChatPasswordInput'
 import { useJoinChannel, useJoinProtectedChannel, useNavBarState } from '@/store/chat'
 import { instance } from '@/util/axios'
+import { useErrorCheck } from '@/store/login'
 
 function ChatPassword(): JSX.Element {
   const passwordRef = useRef<HTMLInputElement>(null)
@@ -20,8 +21,9 @@ function ChatPassword(): JSX.Element {
     setChannelId,
     setChannelAuth,
   } = useJoinChannel()
-
   const { setTabState } = useNavBarState()
+  const { setApiError } = useErrorCheck()
+
   const passwordHandler = async (e) => {
     e.preventDefault()
     const koreanRegex = /[ㄱ-ㅎㅏ-ㅣ가-힣]/g
@@ -61,6 +63,7 @@ function ChatPassword(): JSX.Element {
         setTabState('JOINED')
       }
     } catch (error) {
+      if (error.response.status === 401) setApiError(401)
       console.log('Error : ', error)
       //틀린 비밀번호일 때 예외처리 해야한다.
     }

--- a/pong-game/components/Chat/ChatInfoLog/ChatUserListElement.tsx
+++ b/pong-game/components/Chat/ChatInfoLog/ChatUserListElement.tsx
@@ -67,7 +67,7 @@ function ChatUserListElement(props: ChatUserListElementProps): JSX.Element {
           className={styles.dropdown}
         />
       )}
-      {dropDownState && (
+      {dropDownState && channelUserType && (
         <DropDown
           isDropDownView={dropDownState}
           setIsDropDownView={setDropDownState}

--- a/pong-game/components/Chat/ChatRoomList.tsx
+++ b/pong-game/components/Chat/ChatRoomList.tsx
@@ -6,6 +6,7 @@ import { instance } from '@/util/axios'
 import { useGetChannels } from '@/store/chat'
 import CustomPagination from '../Pagination/CustomPagination'
 import { useNavBarState } from '@/store/chat'
+import { useErrorCheck } from '@/store/login'
 
 function ChatRoomList(): JSX.Element {
   const {
@@ -22,6 +23,7 @@ function ChatRoomList(): JSX.Element {
     totalMe,
   } = useGetChannels()
   const { tabState } = useNavBarState()
+  const { setApiError } = useErrorCheck()
 
   const getAllChannels = useCallback(async () => {
     try {
@@ -31,9 +33,10 @@ function ChatRoomList(): JSX.Element {
       setAllChannels(response.data.channels)
       setTotalAll(response.data.totalDataSize)
     } catch (error) {
+      if (error.response.status === 401) setApiError(401)
       console.log('Error : ', error)
     }
-  }, [setAllChannels, setTotalAll])
+  }, [setAllChannels, setTotalAll, setApiError])
 
   const getMeChannels = useCallback(async () => {
     try {
@@ -43,9 +46,10 @@ function ChatRoomList(): JSX.Element {
       setMeChannels(response.data.channels)
       setTotalMe(response.data.totalDataSize)
     } catch (error) {
+      if (error.response.status === 401) setApiError(401)
       console.log('Error : ', error)
     }
-  }, [setMeChannels, setTotalMe])
+  }, [setMeChannels, setTotalMe, setApiError])
 
   const getDmChannels = useCallback(async () => {
     try {
@@ -55,9 +59,10 @@ function ChatRoomList(): JSX.Element {
       setDmChannels(response.data.dmChannels)
       setTotalDm(response.data.totalItemCount)
     } catch (error) {
+      if (error.response.status === 401) setApiError(401)
       console.log('Error : ', error)
     }
-  }, [setDmChannels, setTotalDm])
+  }, [setDmChannels, setTotalDm, setApiError])
 
   useEffect(() => {
     getAllChannels()

--- a/pong-game/components/Chat/ChatShow.tsx
+++ b/pong-game/components/Chat/ChatShow.tsx
@@ -19,7 +19,6 @@ function ChatShow(): JSX.Element {
     e.preventDefault()
     try {
       socket.emit('message', { channelId: channelId, message: messageRef.current.value })
-      console.log(channelId)
     } catch (error) {
       console.log('Error : ', error)
     }

--- a/pong-game/components/Chat/ChatShow.tsx
+++ b/pong-game/components/Chat/ChatShow.tsx
@@ -8,11 +8,13 @@ import ChatPassword from './ChatInfoLog/ChatPassword'
 import MessageInput from './Input/MessageInput'
 import { useJoinProtectedChannel, useJoinChannel } from '@/store/chat'
 import { socket } from '@/socket/socket'
+import { useErrorCheck } from '@/store/login'
 
 function ChatShow(): JSX.Element {
   const messageRef = useRef<HTMLInputElement>(null)
   const { passwordInputRender } = useJoinProtectedChannel()
   const { channelId } = useJoinChannel()
+  const { setApiError } = useErrorCheck()
   const showType = passwordInputRender === 'CHANNEL' ? styles.show : styles.none
 
   const messageHandler = (e) => {
@@ -20,6 +22,7 @@ function ChatShow(): JSX.Element {
     try {
       socket.emit('message', { channelId: channelId, message: messageRef.current.value })
     } catch (error) {
+      if (error.response.status === 401) setApiError(401)
       console.log('Error : ', error)
     }
     messageRef.current.value = ''

--- a/pong-game/components/Chat/ChatType/ChatTypeListContainer.tsx
+++ b/pong-game/components/Chat/ChatType/ChatTypeListContainer.tsx
@@ -6,9 +6,12 @@ import { useNavBarState } from '@/store/chat'
 import EnteredRoomListSection from './EnteredRoomListSection'
 import { instance } from '@/util/axios'
 import { useGetChannels } from '@/store/chat'
+import { useRouter } from 'next/router'
+import { useErrorCheck } from '@/store/login'
 
 function ChatTypeListContainer(): JSX.Element {
   const { tabState } = useNavBarState()
+  const router = useRouter()
   const {
     setAllChannels,
     setTotalAll,
@@ -19,6 +22,7 @@ function ChatTypeListContainer(): JSX.Element {
     totalDm,
     page,
   } = useGetChannels()
+  const { setApiError } = useErrorCheck()
 
   const getAllChannels = useCallback(async () => {
     try {
@@ -28,9 +32,10 @@ function ChatTypeListContainer(): JSX.Element {
       setAllChannels(response.data.channels)
       setTotalAll(response.data.totalDataSize)
     } catch (error) {
+      if (error.response.status === 401) setApiError(401)
       console.log('Error : ', error)
     }
-  }, [page, setAllChannels, setTotalAll])
+  }, [page, setAllChannels, setTotalAll, setApiError])
 
   const getMeChannels = useCallback(async () => {
     try {
@@ -40,9 +45,10 @@ function ChatTypeListContainer(): JSX.Element {
       setMeChannels(response.data.channels)
       setTotalMe(response.data.totalDataSize)
     } catch (error) {
+      if (error.response.status === 401) setApiError(401)
       console.log('Error : ', error)
     }
-  }, [page, setMeChannels, setTotalMe])
+  }, [page, setMeChannels, setTotalMe, setApiError])
 
   const getDmChannels = useCallback(async () => {
     try {
@@ -52,9 +58,10 @@ function ChatTypeListContainer(): JSX.Element {
       setDmChannels(response.data.dmChannels)
       setTotalDm(response.data.totalItemCount)
     } catch (error) {
+      if (error.response.status === 401) setApiError(401)
       console.log('Error : ', error)
     }
-  }, [page, setDmChannels, setTotalDm])
+  }, [page, setDmChannels, setTotalDm, setApiError])
 
   //"tabState의 변화에 따라서 api요청 보내도록 구현"
   //"ChatRoomListTab.tsx"의 "span"요소에서 할 경우 재 렌더링 문제가 발생해서 위치 변경

--- a/pong-game/components/Chat/ChatType/CreatedRoomList.tsx
+++ b/pong-game/components/Chat/ChatType/CreatedRoomList.tsx
@@ -4,6 +4,7 @@ import passwordRoom from '../../../public/img/chat/lock.svg'
 import { instance } from '@/util/axios'
 import { useJoinChannel, useJoinProtectedChannel, useReadyToChannel } from '@/store/chat'
 import { useModalState } from '@/store/store'
+import { useErrorCheck } from '@/store/login'
 
 interface CreatedRoomListProps {
   title: string //해당 채널의 타이틀
@@ -28,6 +29,8 @@ function CreatedRoomList(props: CreatedRoomListProps): JSX.Element {
   } = useJoinChannel()
   const { setModalName } = useModalState()
   const { setTitle, setReadyChannelId, setReadyChannelType } = useReadyToChannel()
+  const { setApiError } = useErrorCheck()
+
   const passwordIconClassName = props.channelType === 'PROTECTED' ? styles.show : styles.none
 
   const joinChannelHandler = async () => {
@@ -50,6 +53,7 @@ function CreatedRoomList(props: CreatedRoomListProps): JSX.Element {
           setChannelId(props.channelId)
         }
       } catch (error) {
+        if (error.response.status === 401) setApiError(401)
         console.log('Error : ', error)
       }
     } else {
@@ -73,6 +77,7 @@ function CreatedRoomList(props: CreatedRoomListProps): JSX.Element {
             setChannelId(props.channelId)
           }
         } catch (error) {
+          if (error.response.status === 401) setApiError(401)
           console.log('Error : ', error)
         }
       } else {
@@ -87,10 +92,10 @@ function CreatedRoomList(props: CreatedRoomListProps): JSX.Element {
         } else {
           try {
             setReadyChannelId(props.channelId)
-
             setTitle(props.title)
             setModalName('joinRoom') //"PUBLIC"채널에 join 할 시에는 모달창을 띄워서 한번 더 참여 여부를 물어본다.
           } catch (error) {
+            if (error.response.status === 401) setApiError(401)
             console.log('Error : ', error)
           }
         }

--- a/pong-game/components/Chat/ChatType/DmChat.tsx
+++ b/pong-game/components/Chat/ChatType/DmChat.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image'
 import styles from './DmChat.module.scss'
 import { instance } from '@/util/axios'
 import { useJoinChannel, useJoinProtectedChannel } from '@/store/chat'
+import { useErrorCheck } from '@/store/login'
 
 interface DmChantProps {
   channelId: number //해당 dm 고유 id
@@ -20,7 +21,7 @@ function DmChat(props: DmChantProps): JSX.Element {
     setChannelType,
     channelId,
   } = useJoinChannel()
-
+  const { setApiError } = useErrorCheck()
   const userStatus =
     props.status === 'ONLINE' ? styles.profileImageOnline : styles.profileImageOffline
 
@@ -39,6 +40,7 @@ function DmChat(props: DmChantProps): JSX.Element {
         setChannelUserInfo(response.data.channelUsers)
       }
     } catch (error) {
+      if (error.response.status === 401) setApiError(401)
       console.log('Error : ', error)
     }
   }

--- a/pong-game/components/DropDown/Function/ChatBan.tsx
+++ b/pong-game/components/DropDown/Function/ChatBan.tsx
@@ -1,5 +1,7 @@
 import { useModalState, useResponseModalState } from '@/store/store'
 import { instance } from '@/util/axios'
+import { useErrorCheck } from '@/store/login'
+
 interface ChatBanProps {
   channelUserId: number
   nickname: string
@@ -8,6 +10,7 @@ interface ChatBanProps {
 export default function ChatBan(props: ChatBanProps) {
   const { setModalName } = useModalState()
   const responseModal = useResponseModalState()
+  const { setApiError } = useErrorCheck()
 
   const chatUserBanHandler = async () => {
     try {
@@ -19,6 +22,7 @@ export default function ChatBan(props: ChatBanProps) {
           console.log(res)
         })
     } catch (e) {
+      if (e.response.status === 401) setApiError(401)
       console.log(e.message)
     }
   }

--- a/pong-game/components/DropDown/Function/ChatEditAdmin.tsx
+++ b/pong-game/components/DropDown/Function/ChatEditAdmin.tsx
@@ -1,6 +1,7 @@
 import { useJoinChannel } from '@/store/chat'
 import { useModalState, useResponseModalState } from '@/store/store'
 import { instance } from '@/util/axios'
+import { useErrorCheck } from '@/store/login'
 
 interface ChatEditAdminProps {
   channelUserType: 'OWNER' | 'ADMIN' | 'MEMBER'
@@ -13,6 +14,8 @@ export default function ChatEditAdmin(props: ChatEditAdminProps) {
   const { setModalName } = useModalState()
   const responseModal = useResponseModalState()
   const { channelUserInfo, setChannelUserInfo } = useJoinChannel()
+  const { setApiError } = useErrorCheck()
+
   const changeArrayItem = (newType, idToChange) => {
     const result = channelUserInfo.map((item) => {
       if (item.nickname === idToChange) {
@@ -47,6 +50,7 @@ export default function ChatEditAdmin(props: ChatEditAdminProps) {
           }
         })
     } catch (e) {
+      if (e.response.status === 401) setApiError(401)
       console.log(e.message)
     }
   }

--- a/pong-game/components/DropDown/Function/ChatKick.tsx
+++ b/pong-game/components/DropDown/Function/ChatKick.tsx
@@ -1,5 +1,6 @@
 import { useModalState, useResponseModalState } from '@/store/store'
 import { instance } from '@/util/axios'
+import { useErrorCheck } from '@/store/login'
 
 interface ChatEditAdminProps {
   channelUserType: 'OWNER' | 'ADMIN' | 'MEMBER'
@@ -10,6 +11,7 @@ interface ChatEditAdminProps {
 export default function ChatKick(props: ChatEditAdminProps) {
   const { setModalName } = useModalState()
   const responseModal = useResponseModalState()
+  const { setApiError } = useErrorCheck()
 
   const setKickHandler = async () => {
     console.log(props.channelUserId)
@@ -22,6 +24,7 @@ export default function ChatKick(props: ChatEditAdminProps) {
           console.log(res)
         })
     } catch (e) {
+      if (e.response.status === 401) setApiError(401)
       console.log(e.message)
     }
   }

--- a/pong-game/components/DropDown/Function/ChatMute.tsx
+++ b/pong-game/components/DropDown/Function/ChatMute.tsx
@@ -1,5 +1,6 @@
 import { useModalState, useResponseModalState } from '@/store/store'
 import { instance } from '@/util/axios'
+import { useErrorCheck } from '@/store/login'
 
 interface ChatMuteProps {
   channelUserId: number
@@ -10,6 +11,8 @@ interface ChatMuteProps {
 export default function ChatMute(props: ChatMuteProps) {
   const { setModalName } = useModalState()
   const responseModal = useResponseModalState()
+  const { setApiError } = useErrorCheck()
+
   const chatUserMuteHandler = async () => {
     console.log(process.env.NEXT_PUBLIC_API_ENDPOINT)
     try {
@@ -21,6 +24,7 @@ export default function ChatMute(props: ChatMuteProps) {
           console.log(res)
         })
     } catch (e) {
+      if (e.response.status === 401) setApiError(401)
       console.log(e.message)
     }
   }

--- a/pong-game/components/DropDown/Function/EditBlock.tsx
+++ b/pong-game/components/DropDown/Function/EditBlock.tsx
@@ -3,6 +3,8 @@ import { useGetUser } from '@/store/friend'
 import { useModalState, useResponseModalState } from '@/store/store'
 import { instance } from '@/util/axios'
 import { useGetBlocks } from '@/store/friend'
+import { useErrorCheck } from '@/store/login'
+
 interface EditBlockProps {
   isBlocked: boolean
   friendId: number
@@ -10,11 +12,13 @@ interface EditBlockProps {
   calledFrom?: 'searchUserList'
   setIsDropDownView: (v: boolean) => void
 }
+
 export default function EditBlock(props: EditBlockProps) {
   const { channelUserInfo, setChannelUserInfo } = useJoinChannel()
   const responseModal = useResponseModalState()
   const { setModalName } = useModalState()
   const { user, setUser } = useGetUser()
+  const { setApiError } = useErrorCheck()
 
   const changeItem = (newType) => {
     const result = user
@@ -71,6 +75,7 @@ export default function EditBlock(props: EditBlockProps) {
           changeArrayItem(true, props.nickname)
         })
     } catch (e) {
+      if (e.response.status === 401) setApiError(401)
       console.log(e.message)
     }
   }
@@ -95,6 +100,7 @@ export default function EditBlock(props: EditBlockProps) {
           // }
         })
     } catch (e) {
+      if (e.response.status === 401) setApiError(401)
       console.log(e.message)
     }
   }

--- a/pong-game/components/DropDown/Function/EditFriend.tsx
+++ b/pong-game/components/DropDown/Function/EditFriend.tsx
@@ -2,6 +2,7 @@ import { useJoinChannel } from '@/store/chat'
 import { useModalState, useResponseModalState } from '@/store/store'
 import { instance } from '@/util/axios'
 import { useGetFriends, useGetUser } from '@/store/friend'
+import { useErrorCheck } from '@/store/login'
 
 interface EditFriendProps {
   isFriend: boolean
@@ -10,13 +11,14 @@ interface EditFriendProps {
   calledFrom?: 'searchUserList'
   setIsDropDownView: (v: boolean) => void
 }
+
 export default function EditFriend(props: EditFriendProps) {
   const { setModalName } = useModalState()
   const responseModal = useResponseModalState()
   const { channelUserInfo, setChannelUserInfo } = useJoinChannel()
   const { setTotalFriendCount, totalFriendCount } = useGetFriends()
-
   const { user, setUser } = useGetUser()
+  const { setApiError } = useErrorCheck()
 
   const changeItem = (newType) => {
     const result = user
@@ -71,6 +73,7 @@ export default function EditFriend(props: EditFriendProps) {
           changeArrayItem(true, props.nickname)
         })
     } catch (e) {
+      if (e.response.status === 401) setApiError(401)
       console.log(e.message)
     }
   }
@@ -94,6 +97,7 @@ export default function EditFriend(props: EditFriendProps) {
           changeArrayItem(false, props.nickname)
         })
     } catch (e) {
+      if (e.response.status === 401) setApiError(401)
       console.log(e.message)
     }
   }

--- a/pong-game/components/Error/ApiErrorCheck.tsx
+++ b/pong-game/components/Error/ApiErrorCheck.tsx
@@ -1,0 +1,21 @@
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
+import { useErrorCheck } from '@/store/login'
+import { useModalState } from '@/store/store'
+
+function ApiErrorCheck(): JSX.Element {
+  const { apiError } = useErrorCheck()
+  const { setModalName } = useModalState()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (apiError === 401) {
+      router.push('/error')
+      setModalName(null)
+    }
+  }, [apiError])
+
+  return <></>
+}
+
+export default ApiErrorCheck

--- a/pong-game/components/Error/Error.module.scss
+++ b/pong-game/components/Error/Error.module.scss
@@ -1,0 +1,20 @@
+@import '../../styles/colors.scss';
+
+.errorContainer {
+  display: flex;
+  height: 100vh;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  a {
+    margin-top: 32px;
+    font-family: 'Pretendard_SemiBold';
+    font-size: 1.5rem;
+    text-decoration: none;
+    color: $gray_scale_700;
+    transition: 0.3s;
+    &:hover {
+      text-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+    }
+  }
+}

--- a/pong-game/components/Error/Error.tsx
+++ b/pong-game/components/Error/Error.tsx
@@ -1,0 +1,35 @@
+import styles from './Error.module.scss'
+import Image from 'next/image'
+import logo from '@/public/img/login/logo.svg'
+import PageTitle from '../UI/PageTitle'
+import { useErrorCheck } from '@/store/login'
+import Link from 'next/link'
+import { useEffect } from 'react'
+
+function Error(): JSX.Element {
+  const { apiError, duplicateLoginError, setApiError } = useErrorCheck()
+
+  useEffect(() => {
+    setApiError(401)
+    return () => {
+      setApiError(null)
+    }
+  }, [])
+
+  return (
+    <div className={styles.errorContainer}>
+      <Image src={logo} alt={'logo'} />
+      {duplicateLoginError && (
+        <PageTitle title="Error" subTitle="중복된 로그인을 할 수 없습니다." />
+      )}
+      {apiError === 401 && !duplicateLoginError && (
+        <>
+          <PageTitle title="Error" subTitle="세션이 만료되었습니다" />
+          <Link href="/login"> - 로그인 페이지 이동 - </Link>
+        </>
+      )}
+    </div>
+  )
+}
+
+export default Error

--- a/pong-game/components/Friends/FriendUserListContainer.tsx
+++ b/pong-game/components/Friends/FriendUserListContainer.tsx
@@ -8,6 +8,7 @@ import { instance } from '@/util/axios'
 import { useModalState, useResponseModalState } from '@/store/store'
 import { useGetBlocks } from '@/store/friend'
 import { useJoinChannel } from '@/store/chat'
+import { useErrorCheck } from '@/store/login'
 
 interface FriendUserListContainerprops {
   nickname: string
@@ -24,6 +25,8 @@ function FriendUserListContainer(props: FriendUserListContainerprops): JSX.Eleme
   const { channelUserInfo, setChannelUserInfo } = useJoinChannel()
   const { setModalName } = useModalState()
   const { setResponseModalState } = useResponseModalState()
+  const { setApiError } = useErrorCheck()
+
   const baseImg = process.env.NEXT_PUBLIC_API_DEFAULT_PRIFILE_IMAGE
 
   const userStyle = props.isBlocked //block유저이면 styles.block, block유저가 아니면 OFFLINE, ONLINE에 따라서 css 적용
@@ -64,6 +67,7 @@ function FriendUserListContainer(props: FriendUserListContainerprops): JSX.Eleme
           changeArrayItem(false, props.nickname)
         })
     } catch (e) {
+      if (e.response.status === 401) setApiError(401)
       console.log(e.message)
     }
   }

--- a/pong-game/components/Friends/FriendsMainContents.tsx
+++ b/pong-game/components/Friends/FriendsMainContents.tsx
@@ -7,12 +7,14 @@ import { useFriendSetPage, useGetFriends, useGetBlocks, useGetUser } from '@/sto
 import { instance } from '@/util/axios'
 import CustomPagination from '../Pagination/CustomPagination'
 import styles from './FriendsMainContents.module.scss'
+import { useErrorCheck } from '@/store/login'
 
 function FriendsMainContents(): JSX.Element {
   const { tabState, friendPage, setFriendPage } = useFriendSetPage()
   const { setAllFriends, setTotalFriendCount, totalFriendCount } = useGetFriends()
   const { setAllBlocks, setTotalBlockCount, totalBlockCount } = useGetBlocks()
   const { setUser } = useGetUser()
+  const { setApiError } = useErrorCheck()
 
   const getAllFriend = useCallback(async () => {
     try {
@@ -23,9 +25,10 @@ function FriendsMainContents(): JSX.Element {
       setTotalFriendCount(response.data.totalItemCount)
       setUser(null)
     } catch (error) {
+      if (error.response.status === 401) setApiError(401)
       console.log('Error : ', error)
     }
-  }, [friendPage, setAllFriends, setTotalFriendCount, setUser])
+  }, [friendPage, setAllFriends, setTotalFriendCount, setUser, setApiError])
 
   const getAllBlock = useCallback(async () => {
     try {
@@ -36,9 +39,10 @@ function FriendsMainContents(): JSX.Element {
       setTotalBlockCount(response.data.totalItemCount)
       setUser(null)
     } catch (error) {
+      if (error.response.status === 401) setApiError(401)
       console.log('Error : ', error)
     }
-  }, [friendPage, setAllBlocks, setTotalBlockCount, setUser])
+  }, [friendPage, setAllBlocks, setTotalBlockCount, setUser, setApiError])
 
   useEffect(() => {
     if (tabState === 'ALL') getAllFriend()

--- a/pong-game/components/Friends/SearchUsers/SearchUsers.tsx
+++ b/pong-game/components/Friends/SearchUsers/SearchUsers.tsx
@@ -4,12 +4,14 @@ import SearchInputContainer from './SearchInputContainer'
 import SearchUsersListContainer from './SearchUsersListContainer'
 import { instance } from '@/util/axios'
 import { useGetUser } from '@/store/friend'
+import { useErrorCheck } from '@/store/login'
 
 function SearchUsers(): JSX.Element {
   const inputRef = useRef<HTMLInputElement>()
   const { setUser } = useGetUser()
-
+  const { setApiError } = useErrorCheck()
   const patternSpecial = /[~₩;'"!@#$%^&*()_+|<>?:{}\s]/ //특수문자 입력 정규식
+
   const searchNicknameHandler = async (e: FormEvent) => {
     e.preventDefault()
     if (patternSpecial.test(inputRef.current.value)) {
@@ -23,6 +25,7 @@ function SearchUsers(): JSX.Element {
         setUser(response.data)
       }
     } catch (error) {
+      if (error.response.status === 401) setApiError(401)
       console.log('Error : ', error)
     }
 

--- a/pong-game/components/Game/NormalGame.tsx
+++ b/pong-game/components/Game/NormalGame.tsx
@@ -5,6 +5,7 @@ import PageTitle from '../UI/PageTitle'
 import { useModalState } from '@/store/store'
 import { useLodingState } from '@/store/loding'
 import { instance } from '@/util/axios'
+import { useErrorCheck } from '@/store/login'
 
 interface props {
   setPageState: (newPageState: number) => void // setPageState 함수
@@ -19,6 +20,8 @@ export default function NormalGame({ setPageState, setGameState }: props) {
   }
   const { setModalName, setModalProps } = useModalState()
   const { setLodingState } = useLodingState()
+  const { setApiError } = useErrorCheck()
+
   const handleInviteGame = () => {
     console.log(gameMode)
     setModalProps({ modalType: 'GAME', gameMode: gameMode })
@@ -40,6 +43,7 @@ export default function NormalGame({ setPageState, setGameState }: props) {
         gameType: gameMode === 'Normal' ? 'NORMAL_MATCHING' : 'SPECIAL_MATCHING',
       })
     } catch (e) {
+      if (e.response.status === 401) setApiError(401)
       console.log(e.message)
     }
   }

--- a/pong-game/components/Layout/Layout.tsx
+++ b/pong-game/components/Layout/Layout.tsx
@@ -12,6 +12,7 @@ import { useNickNameImage } from '@/store/login'
 import { instance } from '@/util/axios'
 import { useModalState, useResponseModalState } from '@/store/store'
 import { socket } from '@/socket/socket'
+import { useErrorCheck } from '@/store/login'
 
 function Layout({ children }: { children: ReactNode }): JSX.Element {
   const [viewNotiBar, setViewNotiBar] = useState<boolean>(false)
@@ -20,6 +21,7 @@ function Layout({ children }: { children: ReactNode }): JSX.Element {
   const { setAvatar, setMyNickname } = useNickNameImage()
   const { setModalName } = useModalState()
   const responseModal = useResponseModalState()
+  const { setApiError } = useErrorCheck()
 
   const logoutHandler = async () => {
     try {
@@ -30,6 +32,7 @@ function Layout({ children }: { children: ReactNode }): JSX.Element {
       setMyNickname(null)
       setAvatar(null)
     } catch (e) {
+      if (e.response.status === 401) setApiError(401)
       console.log(e.message)
     }
   }

--- a/pong-game/components/Layout/ModalLayout.tsx
+++ b/pong-game/components/Layout/ModalLayout.tsx
@@ -14,6 +14,7 @@ import InviteFriend from '../Modal/InviteFriend/InviteFriend'
 import ChannelSetting from '../Modal/ChannelSetting/ChannelSetting'
 import InviteGameModal from '../Modal/InviteGame/InviteGameModal'
 import Mfa from '../Modal/Mfa/Mfa'
+import DuplicateLogin from '../Modal/DuplicateLogin/DuplicateLogin'
 
 function ModalOverlay(): JSX.Element {
   const { modalName, setModalName } = useModalState()
@@ -32,7 +33,7 @@ function ModalOverlay(): JSX.Element {
         <div
           className={styles.modalOverlay}
           onClick={() => {
-            if (modalName !== 'mfa') {
+            if (modalName !== 'mfa' && modalName !== 'duplicateLogin') {
               setModalName(null)
             }
           }}
@@ -57,6 +58,7 @@ function ModalContent({}): JSX.Element {
     channelSetting: <ChannelSetting />,
     inviteGame: <InviteGameModal />,
     mfa: <Mfa />,
+    duplicateLogin: <DuplicateLogin />,
   }
   return (
     <>

--- a/pong-game/components/Login/InputNickImage.tsx
+++ b/pong-game/components/Login/InputNickImage.tsx
@@ -5,6 +5,7 @@ import styles from './InputNickImage.module.scss'
 import { instance } from '@/util/axios'
 import NickNameInput from './NickNameInput'
 import { useRouter } from 'next/router'
+import { useErrorCheck } from '@/store/login'
 
 const defaultProfileImage = process.env.NEXT_PUBLIC_API_DEFAULT_PRIFILE_IMAGE
 
@@ -14,6 +15,7 @@ function InputNickImage(): JSX.Element {
   const [isValidNick, setIsValidNick] = useState<boolean>(false)
   const inputRef = useRef<HTMLInputElement>(null)
   const router = useRouter()
+  const { setApiError } = useErrorCheck()
   const patternSpecial = /[~₩;'"!@#$%^&*()_+|<>?:{}\s]/ //특수문자 입력 정규식
 
   /* 아바타 사진 리사이징 및 base64 변환 함수 */
@@ -74,6 +76,7 @@ function InputNickImage(): JSX.Element {
           router.replace('/main')
         }
       } catch (error) {
+        if (error.response.status === 401) setApiError(401)
         console.log('Error : ', error)
       }
       setIsValidNick(false)

--- a/pong-game/components/Login/LoginPageContents.tsx
+++ b/pong-game/components/Login/LoginPageContents.tsx
@@ -9,6 +9,7 @@ import Loading from './Loading'
 import { useNickNameImage } from '@/store/login'
 import { useModalState } from '@/store/store'
 import { instance } from '@/util/axios'
+import { useErrorCheck } from '@/store/login'
 
 interface siginInResponse {
   userId: number
@@ -24,6 +25,7 @@ function LoginPageContents(): JSX.Element {
     useNickNameImage()
   const { setModalName } = useModalState()
   const router = useRouter()
+  const { setApiError } = useErrorCheck()
 
   useEffect(() => {
     const urlParams = new URLSearchParams(window.location.search)
@@ -72,13 +74,11 @@ function LoginPageContents(): JSX.Element {
         }
       } catch (error) {
         console.error('Error fetching data:', error)
-        if (error.response.status === 401) {
-          router.replace('/login')
-        }
+        if (error.response.status === 401) setApiError(401)
       }
     }
     fetchData()
-  }, [codeValue, router, setIsMfaEnabled, setMfaQrCOde, setModalName, setUserId])
+  }, [codeValue, router, setIsMfaEnabled, setMfaQrCOde, setModalName, setUserId, setApiError])
 
   return (
     <>

--- a/pong-game/components/Login/LoginPageContents.tsx
+++ b/pong-game/components/Login/LoginPageContents.tsx
@@ -20,7 +20,7 @@ interface siginInResponse {
 function LoginPageContents(): JSX.Element {
   const [responseData, setResponseData] = useState<siginInResponse>()
   const [codeValue, setCodeValue] = useState<string>('')
-  const { setAvatar, setMyNickname, setIsMfaEnabled, setMfaQrCOde, setUserId, mfaQrCode } =
+  const { setAvatar, setMyNickname, setIsMfaEnabled, setMfaQrCOde, setUserId, isMfaEnabled } =
     useNickNameImage()
   const { setModalName } = useModalState()
   const router = useRouter()
@@ -37,14 +37,14 @@ function LoginPageContents(): JSX.Element {
         setMyNickname(null)
         router.replace('/login/info')
       } else {
-        if (mfaQrCode) {
+        if (isMfaEnabled) {
           setModalName('mfa')
         } else {
           router.replace('/main')
         }
       }
     }
-  }, [responseData, router, mfaQrCode, setAvatar, setModalName, setMyNickname])
+  }, [responseData, router, isMfaEnabled, setAvatar, setModalName, setMyNickname])
 
   useEffect(() => {
     if (!codeValue) {
@@ -64,7 +64,7 @@ function LoginPageContents(): JSX.Element {
             setResponseData(res.data)
             setIsMfaEnabled(res.data.isMfaEnabled)
             setUserId(res.data.userId)
-            if (res.data.mfaUrl && res.data.isMfaEnabled) {
+            if (res.data.isMfaEnabled) {
               setMfaQrCOde(res.data.mfaUrl)
               setModalName('mfa')
             }

--- a/pong-game/components/LoginCheck.tsx
+++ b/pong-game/components/LoginCheck.tsx
@@ -2,9 +2,11 @@ import { ReactNode, useEffect } from 'react'
 import { useNickNameImage } from '@/store/login'
 import { instance } from '@/util/axios'
 import { useRouter, NextRouter } from 'next/router'
+import { useErrorCheck } from '@/store/login'
 
 export default function LoginCheck({ children }: { children: ReactNode }) {
   const { setMyNickname, setAvatar, avatar, myNickname } = useNickNameImage()
+  const { setApiError, apiError } = useErrorCheck()
   const router: NextRouter = useRouter()
   const isLoginPage = router.pathname === '/login'
   const isSignPage = router.pathname === '/login/info'
@@ -17,7 +19,8 @@ export default function LoginCheck({ children }: { children: ReactNode }) {
           setAvatar(res.data.avatar)
         }
       })
-    } catch (e) {
+    } catch (error) {
+      if (error.response.status === 401) setApiError(401)
       router.push('/login/info')
     }
   }
@@ -33,8 +36,7 @@ export default function LoginCheck({ children }: { children: ReactNode }) {
       }
     } else if (isSignPage && myNickname !== null && avatar !== null) {
       router.push('/main')
-    }
-    if (!document.cookie && !isLoginPage) {
+    } else if (!document.cookie && !isLoginPage && !apiError && router.pathname !== '/error') {
       router.push('/login')
     }
   }, [router.pathname])
@@ -60,7 +62,7 @@ export default function LoginCheck({ children }: { children: ReactNode }) {
     if (isLoginPage) {
       return
     } else {
-      if (!document.cookie) {
+      if (!document.cookie && !apiError) {
         router.push('/login')
       } else if (myNickname === null || avatar === null) {
         router.push('/login/info')

--- a/pong-game/components/Modal/ChangeImage/ChangeImage.tsx
+++ b/pong-game/components/Modal/ChangeImage/ChangeImage.tsx
@@ -6,6 +6,7 @@ import Image from 'next/image'
 import { useModalState } from '@/store/store'
 import { instance } from '@/util/axios'
 import { useNickNameImage } from '@/store/login'
+import { useErrorCheck } from '@/store/login'
 
 const defaultProfileImage = process.env.NEXT_PUBLIC_API_DEFAULT_PRIFILE_IMAGE
 
@@ -14,6 +15,8 @@ const ChangeImage = (): JSX.Element => {
   const { setAvatar } = useNickNameImage()
   const [uploadImage, setUploadImage] = useState<string>(modalProps.avatar) //기본 이미지를 초기값으로 세팅
   const [imagePreview, setImagePreview] = useState<string>(modalProps.avatar)
+  const { setApiError } = useErrorCheck()
+
   /* 아바타 사진 리사이징 및 base64 변환 함수 */
   const resizeFile = (file) =>
     new Promise((resolve) => {
@@ -62,6 +65,7 @@ const ChangeImage = (): JSX.Element => {
       setModalName(null)
       setAvatar(uploadImage)
     } catch (error) {
+      if (error.response.status === 401) setApiError(401)
       console.log('Error : ', error)
     }
   }

--- a/pong-game/components/Modal/ChannelSetting/ChannelSetting.tsx
+++ b/pong-game/components/Modal/ChannelSetting/ChannelSetting.tsx
@@ -5,6 +5,7 @@ import { useSettingRoomNavBarState, useJoinChannel } from '@/store/chat'
 import PasswordInput from './PasswordInput'
 import { instance } from '@/util/axios'
 import { useModalState, useResponseModalState } from '@/store/store'
+import { useErrorCheck } from '@/store/login'
 
 function ChannelSetting(): JSX.Element {
   const [error, setError] = useState('')
@@ -13,6 +14,7 @@ function ChannelSetting(): JSX.Element {
   const { setModalName } = useModalState()
   const responseModal = useResponseModalState()
   const passwordRef = useRef<HTMLInputElement>()
+  const { setApiError } = useErrorCheck()
   const koreanRegex = /[ㄱ-ㅎㅏ-ㅣ가-힣]/g
 
   const passwordSubmitHandler = async (e) => {
@@ -43,6 +45,7 @@ function ChannelSetting(): JSX.Element {
         setModalName('response')
       }
     } catch (error) {
+      if (error.response.status === 401) setApiError(401)
       console.log('Error : ', error)
     }
   }

--- a/pong-game/components/Modal/CreateRoom/CreateRoom.tsx
+++ b/pong-game/components/Modal/CreateRoom/CreateRoom.tsx
@@ -6,6 +6,7 @@ import CreateRoomInput from './CreateRoomInput/CreateRoomInput'
 import { instance } from '@/util/axios'
 import { useModalState } from '@/store/store'
 import { useGetChannels, useJoinChannel, useJoinProtectedChannel } from '@/store/chat'
+import { useErrorCheck } from '@/store/login'
 
 function CreateChatRoom(): JSX.Element {
   const { tabState, setTabState } = useCreateRoomNavBarState()
@@ -23,6 +24,7 @@ function CreateChatRoom(): JSX.Element {
   } = useJoinChannel()
   const titleRef = useRef<HTMLInputElement>(null)
   const passwordRef = useRef<HTMLInputElement>(null)
+  const { setApiError } = useErrorCheck()
 
   const createChannelHandler = async (channelType, password = null) => {
     const koreanRegex = /[ㄱ-ㅎㅏ-ㅣ가-힣]/g
@@ -93,6 +95,7 @@ function CreateChatRoom(): JSX.Element {
       titleRef.current.value = '' //기존에 남아있던 값을 비워준다.
       channelType !== 'PRIVATE' ? (passwordRef.current.value = '') : '' //채널의 타입이 "PRIVATE"가 아니라면 패스워드값을 비워준다.
     } catch (error) {
+      if (error.response.status === 401) setApiError(401)
       console.log('Api Request fail : ', error)
     }
   }

--- a/pong-game/components/Modal/DuplicateLogin/DuplicateLogin.module.scss
+++ b/pong-game/components/Modal/DuplicateLogin/DuplicateLogin.module.scss
@@ -1,0 +1,12 @@
+.duplicateLoginConatainer {
+  padding: 8px 32px;
+  .duplicateExplanation {
+    margin-top: 32px;
+    font-family: 'Pretendard-Regular';
+    font-size: 1.5rem;
+    text-align: center;
+    strong {
+      line-height: 32px;
+    }
+  }
+}

--- a/pong-game/components/Modal/DuplicateLogin/DuplicateLogin.tsx
+++ b/pong-game/components/Modal/DuplicateLogin/DuplicateLogin.tsx
@@ -1,0 +1,18 @@
+import styles from './DuplicateLogin.module.scss'
+import ModalPageTitle from '@/components/UI/ModalPageTitle'
+
+function DuplicateLogin(): JSX.Element {
+  return (
+    <div className={styles.duplicateLoginConatainer}>
+      <ModalPageTitle title={'중복 로그인'} subTitle="" />
+      <section className={styles.duplicateExplanation}>
+        <strong>
+          이미 다른 곳에서 로그인된 유저는 <br />
+          중복 로그인이 불가능합니다.
+        </strong>
+      </section>
+    </div>
+  )
+}
+
+export default DuplicateLogin

--- a/pong-game/components/Modal/ExitRoom/ExitRoom.tsx
+++ b/pong-game/components/Modal/ExitRoom/ExitRoom.tsx
@@ -3,6 +3,7 @@ import { useGetChannels, useJoinChannel, useJoinProtectedChannel } from '@/store
 import { useModalState } from '@/store/store'
 import { instance } from '@/util/axios'
 import { socket } from '@/socket/socket'
+import { useErrorCheck } from '@/store/login'
 
 function ExitRoom(): JSX.Element {
   const { setPasswordInputRender } = useJoinProtectedChannel() //채널 나가기 모달에 띄워줄 채널 타이틀, api요청에 필요한 채널 id, 채널 나가기 성공할 경우 컴포넌트를 바꿔줄 플래그
@@ -17,6 +18,7 @@ function ExitRoom(): JSX.Element {
   } = useGetChannels()
   const { channelId, setChannelUserInfo, channelTitle, setChannelId } = useJoinChannel()
   const { setModalName } = useModalState() //"확인" 버튼을 클릭했을 때, "취소" 버튼을 클릭했을 때 모달을 꺼주기 위한 set함수
+  const { setApiError } = useErrorCheck()
 
   const exitRoomHandler = async () => {
     //"확인" 버튼을 클릭했을 때, api요청을 실행할 함수
@@ -54,6 +56,7 @@ function ExitRoom(): JSX.Element {
         setPasswordInputRender('DEFAULT') //"chatlog"의 컴포넌트를 "DEFAULT"로 바꿔준다.
       }
     } catch (error) {
+      if (error.response.status === 401) setApiError(401)
       console.log('Error : ', error)
     }
   }

--- a/pong-game/components/Modal/FriendUsersModal/FriendUsersModal.tsx
+++ b/pong-game/components/Modal/FriendUsersModal/FriendUsersModal.tsx
@@ -6,12 +6,13 @@ import UserList from './UserList'
 import { instance } from '@/util/axios'
 import { useGetFriends } from '@/store/friend'
 import { useModalState } from '@/store/store'
+import { useErrorCheck } from '@/store/login'
 
 function FriendUsersModal(): JSX.Element {
   const [page, setPage] = useState(1)
   const { setModalName, modalProps } = useModalState()
-
   const { allFriends, setAllFriends, totalFriendCount } = useGetFriends()
+  const { setApiError } = useErrorCheck()
 
   const getAllFriendHandler = useCallback(async () => {
     try {
@@ -20,9 +21,10 @@ function FriendUsersModal(): JSX.Element {
       })
       setAllFriends(response.data.friends)
     } catch (error) {
+      if (error.response.status === 401) setApiError(401)
       console.log('Error : ', error)
     }
-  }, [page, setAllFriends])
+  }, [page, setAllFriends, setApiError])
 
   const modalOffHandler = () => {
     setModalName(null)

--- a/pong-game/components/Modal/InviteFriend/InviteFriend.tsx
+++ b/pong-game/components/Modal/InviteFriend/InviteFriend.tsx
@@ -3,11 +3,13 @@ import Image from 'next/image'
 import { useReadyToChannel, useJoinChannel } from '@/store/chat'
 import { useModalState } from '@/store/store'
 import { instance } from '@/util/axios'
+import { useErrorCheck } from '@/store/login'
 
 function InviteFriend(): JSX.Element {
   const { title, readyChannelId, dmAvatar } = useReadyToChannel()
   const { channelId } = useJoinChannel()
   const { setModalName } = useModalState()
+  const { setApiError } = useErrorCheck()
 
   const inviteUserHandler = async () => {
     try {
@@ -20,6 +22,7 @@ function InviteFriend(): JSX.Element {
         setModalName(null)
       }
     } catch (error) {
+      if (error.response.status === 401) setApiError(401)
       console.log('Error : ', error)
     }
   }

--- a/pong-game/components/Modal/InviteGame/InviteGameModal.tsx
+++ b/pong-game/components/Modal/InviteGame/InviteGameModal.tsx
@@ -6,12 +6,15 @@ import { useModalState } from '@/store/store'
 import { instance } from '@/util/axios'
 import CustomRadio from '@/function/Game/CustomRadio'
 import { useLodingState } from '@/store/loding'
+import { useErrorCheck } from '@/store/login'
 
 export default function InviteGameModal() {
   const { setModalName, modalProps } = useModalState()
   const { lodingState, setLodingState } = useLodingState()
   const [gameInvitationId, setGameInvitationId] = useState(null)
   const [gameMode, setGameMode] = useState<'Normal' | 'Special'>(modalProps.gameMode)
+  const { setApiError } = useErrorCheck()
+
   useEffect(() => {
     console.log(modalProps.gameMode)
   }, [])
@@ -37,6 +40,7 @@ export default function InviteGameModal() {
         })
       setModalName(null)
     } catch (error) {
+      if (error.response.status === 401) setApiError(401)
       console.log('Error : ', error)
     }
   }

--- a/pong-game/components/Modal/JoinDmRoom/JoinDmRoom.tsx
+++ b/pong-game/components/Modal/JoinDmRoom/JoinDmRoom.tsx
@@ -9,6 +9,7 @@ import {
   useReadyToChannel,
 } from '@/store/chat'
 import { instance } from '@/util/axios'
+import { useErrorCheck } from '@/store/login'
 
 function JoinDmRoom(): JSX.Element {
   const { title, readyChannelId, dmAvatar } = useReadyToChannel()
@@ -18,6 +19,7 @@ function JoinDmRoom(): JSX.Element {
     useJoinChannel()
   const { setDmChannels, setTotalDm } = useGetChannels()
   const router = useRouter()
+  const { setApiError } = useErrorCheck()
 
   const joinDmHandler = async () => {
     const datas = { name: null, channelType: 'DM', password: null, userId: readyChannelId }
@@ -46,6 +48,7 @@ function JoinDmRoom(): JSX.Element {
       }
       setModalName(null)
     } catch (error) {
+      if (error.response.status === 401) setApiError(401)
       console.log('Error : ', error)
     }
   }

--- a/pong-game/components/Modal/JoinRoom/JoinRoom.tsx
+++ b/pong-game/components/Modal/JoinRoom/JoinRoom.tsx
@@ -7,6 +7,7 @@ import {
   useNavBarState,
 } from '@/store/chat'
 import { useModalState } from '@/store/store'
+import { useErrorCheck } from '@/store/login'
 
 function JoinRoom(): JSX.Element {
   const { title, readyChannelId, setReadyChannelId, setTitle, readyChannelType } =
@@ -23,6 +24,7 @@ function JoinRoom(): JSX.Element {
   } = useJoinChannel()
   const { setModalName } = useModalState()
   const { setTabState } = useNavBarState()
+  const { setApiError } = useErrorCheck()
 
   const joinRoomHandler = async () => {
     try {
@@ -46,6 +48,7 @@ function JoinRoom(): JSX.Element {
         setModalName(null)
       }
     } catch (error) {
+      if (error.response.status === 401) setApiError(401)
       setModalName(null)
     }
   }

--- a/pong-game/components/Modal/Mfa/Mfa.module.scss
+++ b/pong-game/components/Modal/Mfa/Mfa.module.scss
@@ -5,17 +5,29 @@
   flex-direction: column;
   padding: 8px 40px;
   align-items: center;
+  width: 400px;
   .qrCode {
     display: flex;
     flex-direction: column;
     align-items: center;
-    margin: 16px 0px;
+    margin: 24px 0px;
+    .newQrCodeExplanation {
+      margin-top: 16px;
+      width: inherit;
+      font-family: 'Pretendard-SemiBold';
+      color: $gray_scale_800;
+      text-align: center;
+      font-size: 1.5rem;
+      line-height: 32px;
+    }
   }
   .qrCodeExplanation {
     width: inherit;
     font-family: 'Pretendard-Regular';
     color: $gray_scale_500;
     text-align: center;
+    font-size: 1.5rem;
+    line-height: 32px;
   }
   .mfaCodeForm {
     width: 100%;
@@ -43,6 +55,7 @@
     .errorMessage {
       color: $error;
       margin-bottom: 16px;
+      font-size: 1.5rem;
     }
     button {
       width: 80px;

--- a/pong-game/components/Modal/Mfa/Mfa.tsx
+++ b/pong-game/components/Modal/Mfa/Mfa.tsx
@@ -40,10 +40,13 @@ function Mfa(): JSX.Element {
   }
 
   const mfaSubmit = async (e) => {
-    const mfaCode = inputRefs.map((ref) => ref.current?.value).join('')
-    const datas = { userId: userId, token: mfaCode }
-    console.log(datas)
     e.preventDefault()
+    const mfaCode = inputRefs.map((ref) => ref.current?.value).join('')
+    if (mfaCode.length < 6) {
+      setError('notEnoughNumber')
+      return
+    }
+    const datas = { userId: userId, token: mfaCode }
     try {
       const response = await instance('/auth/signin/mfa', {
         method: 'patch',
@@ -65,11 +68,17 @@ function Mfa(): JSX.Element {
   return (
     <section className={styles.mfaModalContainer}>
       <ModalPageTitle title="2차인증" subTitle="" />
-      <section className={styles.qrCode}>
-        <QRCode value={mfaQrCode} />
-      </section>
+      {mfaQrCode && (
+        <section className={styles.qrCode}>
+          <QRCode value={mfaQrCode} />
+          <strong className={styles.newQrCodeExplanation}>
+            새로운 QR Code 발급시
+            <br /> 해당 QR Code로 인증을 진행해 주세요.
+          </strong>
+        </section>
+      )}
       <span className={styles.qrCodeExplanation}>
-        &quot;Authenticator&quot; 어플로 위 QR 코드를 촬영 후 나온
+        &quot;Google Authenticator&quot; 어플로 2차인증
         <br />
         여섯자리 숫자를 입력해주세요.
       </span>
@@ -88,6 +97,9 @@ function Mfa(): JSX.Element {
           ))}
         </div>
         {error === 'wrongNumber' && <p className={styles.errorMessage}>잘못된 인증 번호 입니다.</p>}
+        {error === 'notEnoughNumber' && (
+          <p className={styles.errorMessage}>여섯 자리를 모두 입력해주세요.</p>
+        )}
         <button>제 출</button>
       </form>
     </section>

--- a/pong-game/components/Modal/Mfa/Mfa.tsx
+++ b/pong-game/components/Modal/Mfa/Mfa.tsx
@@ -6,6 +6,7 @@ import { useNickNameImage } from '@/store/login'
 import { useModalState } from '@/store/store'
 import QRCode from 'react-qr-code'
 import ModalPageTitle from '@/components/UI/ModalPageTitle'
+import { useErrorCheck } from '@/store/login'
 
 function Mfa(): JSX.Element {
   const [inputValues, setInputValues] = useState(['', '', '', '', '', '']) // 여러 input에 대한 상태 배열
@@ -18,10 +19,10 @@ function Mfa(): JSX.Element {
     useRef<HTMLInputElement>(),
     useRef<HTMLInputElement>(),
   ] // 각 input에 대한 ref 배열
-
   const { mfaQrCode, userId } = useNickNameImage()
   const { setModalName } = useModalState()
   const router = useRouter()
+  const { setApiError } = useErrorCheck()
 
   const handleInputChange = (index, e) => {
     const value = e.target.value
@@ -57,9 +58,8 @@ function Mfa(): JSX.Element {
         router.replace('/main')
       }
     } catch (error) {
-      if (error.response.status === 401) {
-        setError('wrongNumber')
-      }
+      if (error.response.data.message === 'MFA 인증에 실패했습니다.') setError('wrongNumber')
+      else if (error.response.status === 401) setApiError(401)
       console.log('Error : ', error)
     }
   }

--- a/pong-game/components/Modal/ResponseModal/ReseponseModal.module.scss
+++ b/pong-game/components/Modal/ResponseModal/ReseponseModal.module.scss
@@ -18,12 +18,16 @@
     align-items: center;
     justify-content: space-between;
     flex-direction: column;
+    text-align: center;
     h2 {
+      font-family: 'Pretendard-SemiBold';
       font-size: 50px;
       font-weight: 600;
+      text-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
     }
     p {
       font-size: 32px;
+      line-height: 32px;
     }
     .modalActions {
       display: flex;

--- a/pong-game/components/Modal/UserProfile/UserProfileModal.tsx
+++ b/pong-game/components/Modal/UserProfile/UserProfileModal.tsx
@@ -7,6 +7,7 @@ import CustomPagination from '@/components/Pagination/CustomPagination'
 import UserProfileInfo from './UserProfileInfo'
 import { useEffect, useState, useCallback } from 'react'
 import { instance } from '@/util/axios'
+import { useErrorCheck } from '@/store/login'
 
 interface GameHistoryContents {
   rivalName: string
@@ -43,6 +44,7 @@ export default function UserProfile() {
   const [page, setPage] = useState(1)
   const [gameHistories, setGameHistories] = useState<GameHistoryProps>()
   const responseModal = useResponseModalState()
+  const { setApiError } = useErrorCheck()
 
   const getUserProfileHandler = useCallback(async () => {
     try {
@@ -53,10 +55,11 @@ export default function UserProfile() {
       })
     } catch (e) {
       // alert('존재하지 않는 유저입니다.')
+      if (e.response.status === 401) setApiError(401)
       setModalName('response')
       responseModal.setResponseModalState('알림', '잘못된 접근입니다.', null)
     }
-  }, [responseModal, setModalName, userNickname])
+  }, [responseModal, setModalName, userNickname, setApiError])
 
   const getGameHistoryHandler = useCallback(async () => {
     try {
@@ -66,10 +69,11 @@ export default function UserProfile() {
       })
     } catch (e) {
       // alert('존재하지 않는 유저입니다.')
+      if (e.response.status === 401) setApiError(401)
       setModalName('response')
       responseModal.setResponseModalState('알림', '잘못된 접근입니다.', null)
     }
-  }, [page, responseModal, setModalName, userNickname])
+  }, [page, responseModal, setModalName, userNickname, setApiError])
 
   useEffect(() => {
     setUserNickname(modalProps.nickname)

--- a/pong-game/components/Socket/Channel/ErrorMessage.tsx
+++ b/pong-game/components/Socket/Channel/ErrorMessage.tsx
@@ -1,0 +1,23 @@
+import { socket } from '@/socket/socket'
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
+import { useErrorCheck } from '@/store/login'
+
+export default function ErrorMeassage() {
+  const router = useRouter()
+  const { setDuplicateError } = useErrorCheck()
+
+  useEffect(() => {
+    socket.on('error', (error: any) => {
+      socket.disconnect()
+      setDuplicateError(true)
+      router.push('/error')
+    })
+
+    return () => {
+      socket.off('error')
+    }
+  }, [])
+
+  return <></>
+}

--- a/pong-game/components/Socket/Channel/GameInvitation.tsx
+++ b/pong-game/components/Socket/Channel/GameInvitation.tsx
@@ -4,6 +4,7 @@ import toast from 'react-hot-toast'
 import styles from './GameInvitation.module.scss'
 import { instance } from '@/util/axios'
 import { useRouter, NextRouter } from 'next/router'
+import { useErrorCheck } from '@/store/login'
 
 interface toastData {
   invitationId: number
@@ -15,6 +16,7 @@ interface toastData {
 
 export default function GameInvitation() {
   const router: NextRouter = useRouter()
+  const { setApiError } = useErrorCheck()
 
   const notify = (props: toastData) =>
     toast(
@@ -26,6 +28,7 @@ export default function GameInvitation() {
               console.log('수락 성공')
             })
           } catch (e) {
+            if (e.response.status === 401) setApiError(401)
             console.log(e.message)
           }
         }
@@ -36,6 +39,7 @@ export default function GameInvitation() {
               console.log('거절 성공')
             })
           } catch (e) {
+            if (e.response.status === 401) setApiError(401)
             console.log(e.message)
           }
         }

--- a/pong-game/components/Socket/Channel/PrivateInvitation.tsx
+++ b/pong-game/components/Socket/Channel/PrivateInvitation.tsx
@@ -5,10 +5,12 @@ import { useRouter } from 'next/router'
 import { socket } from '@/socket/socket'
 import { useGetBlocks } from '@/store/friend'
 import { useJoinChannel, useJoinProtectedChannel, useNavBarState } from '@/store/chat'
+import { useModalState } from '@/store/store'
 import styles from './PrivateInvitation.module.scss'
 
 function PrivateInvitation(): JSX.Element {
   const router = useRouter()
+  const { setModalName } = useModalState()
   const { allBlocks } = useGetBlocks()
   const {
     setChannelLogEmpty,
@@ -37,6 +39,7 @@ function PrivateInvitation(): JSX.Element {
           method: 'get',
           data: JSON.stringify(postData),
         })
+        setModalName(null)
         setChannelLogEmpty([])
         setPasswordInputRender('CHANNEL')
         setChannelTitle(response.data.channelName)
@@ -61,6 +64,7 @@ function PrivateInvitation(): JSX.Element {
       setChannelUserInfo,
       setPasswordInputRender,
       setTabState,
+      setModalName,
     ],
   )
 

--- a/pong-game/components/Socket/Channel/PrivateInvitation.tsx
+++ b/pong-game/components/Socket/Channel/PrivateInvitation.tsx
@@ -6,6 +6,7 @@ import { socket } from '@/socket/socket'
 import { useGetBlocks } from '@/store/friend'
 import { useJoinChannel, useJoinProtectedChannel, useNavBarState } from '@/store/chat'
 import { useModalState } from '@/store/store'
+import { useErrorCheck } from '@/store/login'
 import styles from './PrivateInvitation.module.scss'
 
 function PrivateInvitation(): JSX.Element {
@@ -22,6 +23,7 @@ function PrivateInvitation(): JSX.Element {
   } = useJoinChannel()
   const { setPasswordInputRender } = useJoinProtectedChannel()
   const { setTabState } = useNavBarState()
+  const { setApiError } = useErrorCheck()
 
   const acceptHandler = useCallback(
     async (t, invitationId) => {
@@ -50,6 +52,7 @@ function PrivateInvitation(): JSX.Element {
         setChannelAuth('MEMBER')
         toast.remove(t.id)
       } catch (error) {
+        if (error.response.status === 401) setApiError(401)
         toast.remove(t.id)
         console.log('Error : ', error)
       }
@@ -65,6 +68,7 @@ function PrivateInvitation(): JSX.Element {
       setPasswordInputRender,
       setTabState,
       setModalName,
+      setApiError,
     ],
   )
 

--- a/pong-game/components/Socket/ChannelSocketHandler.tsx
+++ b/pong-game/components/Socket/ChannelSocketHandler.tsx
@@ -1,32 +1,39 @@
 import { socket } from '@/socket/socket'
 import { useEffect } from 'react'
-
 import GameInvitation from './Channel/GameInvitation'
 import PrivateInvitation from './Channel/PrivateInvitation'
 import ChannelMessage from './Channel/ChannelMesage'
 import GameInvitationReply from './Channel/GameInvitationReply'
+import ErrorMeassage from './Channel/ErrorMessage'
+import { useNickNameImage } from '@/store/login'
 
 export default function ChannelSocketHandler() {
+  const { myNickname } = useNickNameImage()
+
   useEffect(() => {
     try {
-      socket.connect()
-      socket.on('connect', () => {
-        console.log('channel connect')
-      })
+      if (myNickname !== null && myNickname !== 'nicknameDefault') {
+        socket.connect()
+        socket.on('connect', () => {
+          console.log('channel connect')
+        })
+      }
     } catch (error) {
       console.log('Error : ', error)
     }
     return () => {
+      socket.close()
       socket.disconnect()
-      socket.off('connect')
+      // socket.off('connect')
     }
-  }, [])
+  }, [myNickname])
   return (
     <>
       <ChannelMessage />
       <GameInvitation />
       <PrivateInvitation />
       <GameInvitationReply />
+      <ErrorMeassage />
     </>
   )
 }

--- a/pong-game/components/Socket/ChannelSocketHandler.tsx
+++ b/pong-game/components/Socket/ChannelSocketHandler.tsx
@@ -1,6 +1,5 @@
 import { socket } from '@/socket/socket'
 import { useEffect } from 'react'
-import { useRouter } from 'next/router'
 
 import GameInvitation from './Channel/GameInvitation'
 import PrivateInvitation from './Channel/PrivateInvitation'
@@ -8,10 +7,9 @@ import ChannelMessage from './Channel/ChannelMesage'
 import GameInvitationReply from './Channel/GameInvitationReply'
 
 export default function ChannelSocketHandler() {
-  const router = useRouter()
   useEffect(() => {
     try {
-      const socketResponse = socket.connect()
+      socket.connect()
       socket.on('connect', () => {
         console.log('channel connect')
       })

--- a/pong-game/next.config.js
+++ b/pong-game/next.config.js
@@ -3,7 +3,7 @@ const nextConfig = {
   compiler: {
     styledComponents: true,
   },
-  reactStrictMode: true,
+  reactStrictMode: false,
 }
 
 module.exports = nextConfig

--- a/pong-game/package-lock.json
+++ b/pong-game/package-lock.json
@@ -11,7 +11,7 @@
         "@svgr/webpack": "^8.1.0",
         "axios": "^1.6.0",
         "cookie": "^0.6.0",
-        "cookies-next": "^4.0.0",
+        "cookies-next": "^4.1.0",
         "next": "13.5.4",
         "next-transpile-modules": "^10.0.1",
         "react": "^18",
@@ -3629,9 +3629,9 @@
       }
     },
     "node_modules/cookies-next": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cookies-next/-/cookies-next-4.0.0.tgz",
-      "integrity": "sha512-3TyzeltFCGgdOlVOVTPClSq+YV9ZCdOyA3aHRZv9f5aSgg7EyI4NSvXFOCgzT/xIxeHR4Rz8/z5Tdo9oPqaVpA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cookies-next/-/cookies-next-4.1.0.tgz",
+      "integrity": "sha512-BREVc4TJT4NwXfyKjdjnYFXM6iRns+MYpCd34ClXuYqeisXnkPkbq7Ok9xaqi9mHmV6H2rwPE+p3EpMz4pF/kQ==",
       "dependencies": {
         "@types/cookie": "^0.4.1",
         "@types/node": "^16.10.2",
@@ -10765,9 +10765,9 @@
       "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="
     },
     "cookies-next": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cookies-next/-/cookies-next-4.0.0.tgz",
-      "integrity": "sha512-3TyzeltFCGgdOlVOVTPClSq+YV9ZCdOyA3aHRZv9f5aSgg7EyI4NSvXFOCgzT/xIxeHR4Rz8/z5Tdo9oPqaVpA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cookies-next/-/cookies-next-4.1.0.tgz",
+      "integrity": "sha512-BREVc4TJT4NwXfyKjdjnYFXM6iRns+MYpCd34ClXuYqeisXnkPkbq7Ok9xaqi9mHmV6H2rwPE+p3EpMz4pF/kQ==",
       "requires": {
         "@types/cookie": "^0.4.1",
         "@types/node": "^16.10.2",

--- a/pong-game/package.json
+++ b/pong-game/package.json
@@ -12,7 +12,7 @@
     "@svgr/webpack": "^8.1.0",
     "axios": "^1.6.0",
     "cookie": "^0.6.0",
-    "cookies-next": "^4.0.0",
+    "cookies-next": "^4.1.0",
     "next": "13.5.4",
     "next-transpile-modules": "^10.0.1",
     "react": "^18",

--- a/pong-game/pages/404.tsx
+++ b/pong-game/pages/404.tsx
@@ -1,10 +1,3 @@
-import { useEffect } from 'react'
-import { useRouter } from 'next/router'
-
 export default function Error() {
-  const router = useRouter()
-  useEffect(() => {
-    router.replace('/main')
-  }, [router])
   return <></>
 }

--- a/pong-game/pages/_app.tsx
+++ b/pong-game/pages/_app.tsx
@@ -1,5 +1,6 @@
 import '@/styles/globals.css'
 import { Reset } from 'styled-reset'
+import { useRouter } from 'next/router'
 import type { AppProps } from 'next/app'
 import Layout from '@/components/Layout/Layout'
 import ModalLayout from '@/components/Layout/ModalLayout'
@@ -8,28 +9,35 @@ import SocketConnect from '@/components/SocketConnect'
 import { Toaster } from 'react-hot-toast'
 import Loding from '@/components/Loding/Loding'
 import { QueryClient, QueryClientProvider } from 'react-query'
+import { useErrorCheck } from '@/store/login'
+import ApiErrorCheck from '@/components/Error/ApiErrorCheck'
 
 export default function App({ Component, pageProps }: AppProps) {
   const queryClient = new QueryClient()
+  const { duplicateLoginError, apiError } = useErrorCheck()
+
   return (
     <>
       <Reset />
       <LoginCheck>
         <QueryClientProvider client={queryClient}>
-          {/* <Loding> */}
+          <ApiErrorCheck />
           <Loding />
-          <Layout>
-            <SocketConnect />
+          {!duplicateLoginError && !apiError ? (
+            <Layout>
+              <SocketConnect />
+              <Component {...pageProps} />
+              <Toaster
+                toastOptions={{
+                  style: {
+                    maxWidth: 850,
+                  },
+                }}
+              />
+            </Layout>
+          ) : (
             <Component {...pageProps} />
-            <Toaster
-              toastOptions={{
-                style: {
-                  maxWidth: 850,
-                },
-              }}
-            />
-          </Layout>
-          {/* </Loding> */}
+          )}
         </QueryClientProvider>
       </LoginCheck>
       <ModalLayout />

--- a/pong-game/pages/error/index.tsx
+++ b/pong-game/pages/error/index.tsx
@@ -1,0 +1,11 @@
+import Error from '@/components/Error/Error'
+
+function ErrorPage() {
+  return (
+    <>
+      <Error />
+    </>
+  )
+}
+
+export default ErrorPage

--- a/pong-game/pages/main/index.tsx
+++ b/pong-game/pages/main/index.tsx
@@ -8,6 +8,7 @@ import { socket } from '@/socket/socket'
 import { instance } from '@/util/axios'
 import { useLodingState } from '@/store/loding'
 import { useMatchGameState } from '@/store/game'
+import { useErrorCheck } from '@/store/login'
 
 interface gameMatchedData {
   gameId: number
@@ -19,6 +20,7 @@ export default function Home() {
   const router: NextRouter = useRouter()
   const { setLodingState } = useLodingState()
   const { setMatchGameState } = useMatchGameState()
+  const { setApiError } = useErrorCheck()
 
   const onClickLadderBtn = async () => {
     try {
@@ -32,6 +34,7 @@ export default function Home() {
       })
       // router.push('/match')
     } catch (e) {
+      if (e.response.status === 401) setApiError(401)
       console.log(e.message)
     }
   }

--- a/pong-game/pages/mypage/index.tsx
+++ b/pong-game/pages/mypage/index.tsx
@@ -56,10 +56,10 @@ export default function Mypage(props) {
   // }
 
   useEffect(() => {
-    getGameHistoryHandler
+    // getGameHistoryHandler()
     setUserProfile(props.data)
     setAvatar(props.data.avatar)
-  }, [page])
+  }, [page, setAvatar, props.data])
 
   // useEffect(() => {
   //   getUserProfileHandler

--- a/pong-game/pages/mypage/index.tsx
+++ b/pong-game/pages/mypage/index.tsx
@@ -115,7 +115,7 @@ export async function getServerSideProps(context) {
   if (!Object.keys(mycookie).length) {
     return {
       redirect: {
-        destination: '/login',
+        destination: '/error',
         permanent: false,
       },
     }

--- a/pong-game/pages/mypage/index.tsx
+++ b/pong-game/pages/mypage/index.tsx
@@ -72,17 +72,19 @@ export default function Mypage(props) {
         subTitle="프로필 사진, 상태메세지 변경과 내 전적을 확인할 수 있어요."
       />
       {/* serverSide 데이터 페칭으로 한 데이터 props로 전달 */}
-      <MyPageProfile
-        nickName={userProfile.nickname}
-        avatar={userProfile.avatar}
-        statusMessage={userProfile.statusMessage}
-        loseCount={userProfile.loseCount}
-        winCount={userProfile.winCount}
-        totalCount={userProfile.totalCount}
-        ladderRank={userProfile.ladderRank}
-        ladderScore={userProfile.ladderScore}
-        ladderMaxScore={userProfile.ladderMaxScore}
-      />
+      {userProfile && (
+        <MyPageProfile
+          nickName={userProfile.nickname}
+          avatar={userProfile.avatar}
+          statusMessage={userProfile.statusMessage}
+          loseCount={userProfile.loseCount}
+          winCount={userProfile.winCount}
+          totalCount={userProfile.totalCount}
+          ladderRank={userProfile.ladderRank}
+          ladderScore={userProfile.ladderScore}
+          ladderMaxScore={userProfile.ladderMaxScore}
+        />
+      )}
       <section className={styles.history}>
         <div className={styles.historyList}>
           {gameHistories && (

--- a/pong-game/pages/rank/index.tsx
+++ b/pong-game/pages/rank/index.tsx
@@ -5,6 +5,7 @@ import CustomPagination from '@/components/Pagination/CustomPagination'
 import RankUserList from '@/components/Rank/RankUserList'
 import axios from 'axios'
 import https from 'https'
+import { useRouter } from 'next/router'
 
 interface RankInfo {
   rankUsers: RankUsers[]
@@ -23,6 +24,7 @@ export default function Rank(props) {
   const [paginatedRankUsers, setPaginatedRankUsers] = useState<RankUsers[]>(
     props.data.rankUsers.slice(0, 10),
   )
+  const router = useRouter()
   // console.log(props.data)
   // useEffect(() => {}, [])
   // const getRankListHandler = async () => {
@@ -40,7 +42,7 @@ export default function Rank(props) {
   useEffect(() => {
     setPaginatedRankUsers(props.data.rankUsers.slice((page - 1) * 10, page * 10))
     setRankData(props.data)
-    // console.log(rankData.totalItemCount)
+    if (!document.cookie) router.push('/error')
   }, [page, props.data, setRankData]) // 여기에 api호출 넣으면 될듯~
 
   return (

--- a/pong-game/pages/rank/index.tsx
+++ b/pong-game/pages/rank/index.tsx
@@ -19,7 +19,7 @@ interface RankUsers {
 
 export default function Rank(props) {
   const [page, setPage] = useState(1)
-  const [rankData, setRankData] = useState<RankInfo>(props.data)
+  const [rankData, setRankData] = useState<RankInfo>(null)
   const [paginatedRankUsers, setPaginatedRankUsers] = useState<RankUsers[]>(
     props.data.rankUsers.slice(0, 10),
   )
@@ -39,8 +39,9 @@ export default function Rank(props) {
   // }
   useEffect(() => {
     setPaginatedRankUsers(props.data.rankUsers.slice((page - 1) * 10, page * 10))
+    setRankData(props.data)
     // console.log(rankData.totalItemCount)
-  }, [page]) // 여기에 api호출 넣으면 될듯~
+  }, [page, props.data, setRankData]) // 여기에 api호출 넣으면 될듯~
 
   return (
     <div className={styles.backGround}>

--- a/pong-game/store/login.tsx
+++ b/pong-game/store/login.tsx
@@ -2,6 +2,19 @@ import { create } from 'zustand'
 
 const defaultProfileImage = process.env.NEXT_PUBLIC_API_DEFAULT_PROFILE_IMAGE
 
+interface useErrorCheckProps {
+  duplicateLoginError: boolean
+  apiError?: number
+  setDuplicateError: (v: boolean) => void
+  setApiError: (v: number) => void
+}
+
+export const useErrorCheck = create<useErrorCheckProps>((set) => ({
+  duplicateLoginError: false,
+  setDuplicateError: (duplicateLoginError) => set({ duplicateLoginError }),
+  setApiError: (apiError) => set({ apiError }),
+}))
+
 interface useNicknameImageProps {
   avatar: string
   myNickname: string
@@ -17,7 +30,7 @@ interface useNicknameImageProps {
 
 export const useNickNameImage = create<useNicknameImageProps>((set) => ({
   userId: null,
-  myNickname: 'nickname',
+  myNickname: 'nicknameDefault',
   avatar: defaultProfileImage,
   setMyNickname: (myNickname) => set({ myNickname }),
   setAvatar: (avatar) => set({ avatar }),

--- a/pong-game/store/store.tsx
+++ b/pong-game/store/store.tsx
@@ -24,6 +24,7 @@ interface ModalState {
     | 'channelSetting'
     | 'inviteGame'
     | 'mfa'
+    | 'duplicateLogin'
     | null
   setModalName: (
     modalName:
@@ -41,6 +42,7 @@ interface ModalState {
       | 'channelSetting'
       | 'inviteGame'
       | 'mfa'
+      | 'duplicateLogin'
       | null,
   ) => void
   modalProps?: ModalProps | null

--- a/pong-game/util/axios.tsx
+++ b/pong-game/util/axios.tsx
@@ -45,7 +45,7 @@ instance.interceptors.response.use(
     } else if (error.response && error.response.status === 404) {
       alert('잘못된 요청입니다.')
     } else if (error.response && error.response.status === 401) {
-      window.location.href = 'https://localhost:8001/login'
+      // window.location.href = 'https://localhost:8001/login'
     }
     return Promise.reject(error)
   },

--- a/pong-game/util/axios.tsx
+++ b/pong-game/util/axios.tsx
@@ -1,8 +1,6 @@
 import axios from 'axios'
 import https from 'https'
 
-import { useRouter } from 'next/router'
-
 const baseURL = process.env.NEXT_PUBLIC_API_ENDPOINT
 
 const instance = axios.create({
@@ -34,7 +32,7 @@ instance.interceptors.response.use(
     // const { setResponseModalState }= useResponseModalState()
     // const router: NextRouter = useRouter()
     if (error.response && error.response.status === 400) {
-      alert('유효하지 않은 요청입니다.')
+      alert(error.response.data.message)
       console.log(error.response.data.message)
       // setResponseModalState('에러', error.response.data.message, null)
       // setModalName('response')


### PR DESCRIPTION
- api요청시 401(토큰인증)에러 처리
   - api에러 status를 담당하는 전역변수를 하나 만들어서 해당 전역변수로 에러넘버 관리
   - "ApiErrorCheck"컴포넌트를 만들어서 해당 컴포넌트에서 "401"에러 일시 에러페이지로 리다이렉션
   - 만약 모달이 띄워져 있는 상태라면 "setModalName" null값으로 초기화
   - 중복로그인시 해당 에러 페이지로 리다이렉션
   - 401에러일시 해당 에러페이지로 이동 후  "Link"컴포넌트를 통해서 사용자가 로그인페이지로 이동

- eslint에 맞춰서 파일 수정
   - error인 부분을 중점으로 고치고 warning부분은 냅둘 예정